### PR TITLE
build: add CMAKE_CL_SHOWINCLUDES_PREFIX to CMakePresets.json

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -123,7 +123,8 @@
         "CMAKE_C_COMPILER": "clang-cl",
         "CMAKE_CXX_COMPILER": "clang-cl",
         "CMAKE_C_COMPILER_TARGET": "i386-pc-windows-msvc",
-        "CMAKE_CXX_COMPILER_TARGET": "i386-pc-windows-msvc"
+        "CMAKE_CXX_COMPILER_TARGET": "i386-pc-windows-msvc",
+        "CMAKE_CL_SHOWINCLUDES_PREFIX": "Note: including file:"
       },
       "vendor": {
         "microsoft.com/VisualStudioSettings/CMake/1.0": {


### PR DESCRIPTION
Fixes an issue where the Windows build using Ninja and clang-cl fails due to incorrect parsing of included files. The prefix 'Note: including file:' is added to correctly interpret the output of the compiler and prevent the 'FindFirstFileExA' error.