### PR TITLE
build(linux): update IntelLLVM compiler flags

### DIFF
--- a/cmake/CompileOptionsLinuxIntelLLVM.cmake
+++ b/cmake/CompileOptionsLinuxIntelLLVM.cmake
@@ -81,7 +81,7 @@ function(configure_compile_options)
 
         $<$<OR:$<CONFIG:Release>,$<CONFIG:MinSizeRel>,$<CONFIG:RelWithDebInfo>>:
           -finline-functions      # Inline suitable functions
-          -freroll-loops          # Turn on loop reroller
+          -funroll-loops          # Turn on loop unroller
           -fvectorize             # Enable the loop vectorization passes
         >
     )


### PR DESCRIPTION
Replaced `-freroll-loops` with `-funroll-loops` to fix compilation with the latest IntelLLVM compiler.